### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/890/517/445/890517445.geojson
+++ b/data/890/517/445/890517445.geojson
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":890517445,
-    "wof:lastmodified":1601068497,
+    "wof:lastmodified":1601423136,
     "wof:name":"Easter Island",
     "wof:parent_id":1108786421,
     "wof:placetype":"locality",

--- a/data/890/517/445/890517445.geojson
+++ b/data/890/517/445/890517445.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:eng_x_preferred":[
+        "Easter Island"
+    ],
+    "name:rus_x_preferred":[
+        "\u041e\u0441\u0442\u0440\u043e\u0432 \u041f\u0430\u0441\u0445\u0438"
+    ],
     "qs:name":"\u041e\u0441\u0442\u0440\u043e\u0432 \u041f\u0430\u0441\u0445\u0438",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -48,8 +54,8 @@
         }
     ],
     "wof:id":890517445,
-    "wof:lastmodified":1566644622,
-    "wof:name":"\u041e\u0441\u0442\u0440\u043e\u0432 \u041f\u0430\u0441\u0445\u0438",
+    "wof:lastmodified":1601068497,
+    "wof:name":"Easter Island",
     "wof:parent_id":1108786421,
     "wof:placetype":"locality",
     "wof:population":4000,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.