### PR TITLE
Update properties of megacities

### DIFF
--- a/data/102/016/833/102016833.geojson
+++ b/data/102/016/833/102016833.geojson
@@ -21,7 +21,7 @@
     "mps:longitude":-71.620322,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":6.0,
+    "mz:min_zoom":5.0,
     "name:abk_x_preferred":[
         "\u0412\u0430\u043b\u043f\u0430\u0440\u0430\u0438\u0441\u043e"
     ],
@@ -820,6 +820,7 @@
         "fb:id":"en.valparaiso",
         "gn:id":3868626,
         "loc:id":"n81018779",
+        "ne:id":1159150931,
         "nyt:id":"N63886586962019524001",
         "qs_pg:id":353395,
         "wd:id":"Q33986",
@@ -840,7 +841,8 @@
         }
     ],
     "wof:id":102016833,
-    "wof:lastmodified":1607390899,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Valpara\u00edso",
     "wof:parent_id":102063161,
     "wof:placetype":"locality",

--- a/data/102/016/915/102016915.geojson
+++ b/data/102/016/915/102016915.geojson
@@ -24,7 +24,7 @@
     "mps:longitude":-70.630133,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":4.0,
+    "mz:min_zoom":2.0,
     "name:abk_x_preferred":[
         "\u0421\u0430\u043d\u0442\u0438\u0430\u0433\u043e \u0434\u0435 \u0427\u0438\u043b\u0438"
     ],
@@ -913,6 +913,7 @@
         "gn:id":3871336,
         "gp:id":349859,
         "loc:id":"n79077402",
+        "ne:id":1159151615,
         "nyt:id":"N16164022079959354031",
         "qs_pg:id":776654,
         "wd:id":"Q2887",
@@ -936,7 +937,8 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1607390899,
+    "wof:lastmodified":1608688193,
+    "wof:megacity":1,
     "wof:name":"Santiago",
     "wof:parent_id":102063117,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary