### PR TITLE
cl concordances, placetype local, and more

### DIFF
--- a/data/102/063/073/102063073.geojson
+++ b/data/102/063/073/102063073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.025345,
-    "geom:area_square_m":67881689173.218529,
+    "geom:area_square_m":67881688787.638329,
     "geom:bbox":"-70.738609,-26.057821,-68.065038,-22.425123",
     "geom:latitude":-24.327334,
     "geom:longitude":-69.568962,
@@ -175,11 +175,12 @@
         "hasc:id":"CL.AN.AN",
         "wd:id":"Q94552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0034694809e8d618cdbd9890c5e41f69",
+    "wof:geomhash":"b9036e81992d4d814e3de133157751ce",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":102063073,
-    "wof:lastmodified":1690866791,
+    "wof:lastmodified":1695886627,
     "wof:name":"Antofagasta",
     "wof:parent_id":85682175,
     "wof:placetype":"county",

--- a/data/102/063/075/102063075.geojson
+++ b/data/102/063/075/102063075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.974402,
-    "geom:area_square_m":36938558137.012871,
+    "geom:area_square_m":36938558170.666039,
     "geom:bbox":"-74.706787,-54.495392,-68.436333,-52.00222",
     "geom:latitude":-53.089193,
     "geom:longitude":-71.737161,
@@ -172,11 +172,12 @@
         "hasc:id":"CL.MA.MG",
         "wd:id":"Q684369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"661ea8ef32526f4d7642b90e76424f53",
+    "wof:geomhash":"8b3da202dc764494510bb34c2c3c262d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":102063075,
-    "wof:lastmodified":1690866795,
+    "wof:lastmodified":1695886538,
     "wof:name":"Magallanes",
     "wof:parent_id":85682211,
     "wof:placetype":"county",

--- a/data/102/063/077/102063077.geojson
+++ b/data/102/063/077/102063077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.440232,
-    "geom:area_square_m":4599221670.870373,
+    "geom:area_square_m":4599221664.911881,
     "geom:bbox":"-71.543679,-32.683614,-70.411345,-32.020791",
     "geom:latitude":-32.339184,
     "geom:longitude":-71.005383,
@@ -175,11 +175,12 @@
         "wd:id":"Q721557",
         "wk:page":"Petorca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a6e5c2e9aed690bedd38ad70b87f37b",
+    "wof:geomhash":"98421e72666091a75eb891e913988f2f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":102063077,
-    "wof:lastmodified":1690866761,
+    "wof:lastmodified":1695886466,
     "wof:name":"Petorca",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/079/102063079.geojson
+++ b/data/102/063/079/102063079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.452183,
-    "geom:area_square_m":12673165841.874767,
+    "geom:area_square_m":12673166921.852642,
     "geom:bbox":"-72.931571,-46.138433,-71.089331,-43.925254",
     "geom:latitude":-45.1052,
     "geom:longitude":-71.925117,
@@ -169,11 +169,12 @@
         "wd:id":"Q201277",
         "wk:page":"Coyhaique"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea0b94152f8f19ed7c05c61ce8349171",
+    "wof:geomhash":"1b4408ebb9055ea574409b1c632852d7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":102063079,
-    "wof:lastmodified":1690866760,
+    "wof:lastmodified":1695886465,
     "wof:name":"Coyhaique",
     "wof:parent_id":85682189,
     "wof:placetype":"county",

--- a/data/102/063/081/102063081.geojson
+++ b/data/102/063/081/102063081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.970998,
-    "geom:area_square_m":54507888561.099831,
+    "geom:area_square_m":54507888288.442879,
     "geom:bbox":"-75.690437,-52.805279,-71.605347,-48.595795",
     "geom:latitude":-50.767452,
     "geom:longitude":-73.853637,
@@ -204,11 +204,12 @@
         "qs_pg:id":977584,
         "wd:id":"Q721769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"df0f48888371a490ac7f167df1c927cc",
+    "wof:geomhash":"adc04d66d2de2441f09182e3a4e45948",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -236,7 +237,7 @@
         }
     ],
     "wof:id":102063081,
-    "wof:lastmodified":1690866792,
+    "wof:lastmodified":1695886528,
     "wof:name":"Ultima Esperanza",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/102/063/083/102063083.geojson
+++ b/data/102/063/083/102063083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395827,
-    "geom:area_square_m":4069338194.227802,
+    "geom:area_square_m":4069338526.181506,
     "geom:bbox":"-71.714492,-34.184196,-70.791801,-33.197876",
     "geom:latitude":-33.754829,
     "geom:longitude":-71.198039,
@@ -179,11 +179,12 @@
         "wd:id":"Q721498",
         "wk:page":"Melipilla"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4288a16c8a95d75af26ac5208f8228d7",
+    "wof:geomhash":"0f4a0ea3a55ea6d0b6ffd8a5f7f7d49b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":102063083,
-    "wof:lastmodified":1690866762,
+    "wof:lastmodified":1695886467,
     "wof:name":"Melipilla",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/091/102063091.geojson
+++ b/data/102/063/091/102063091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.599305,
-    "geom:area_square_m":17156228090.551104,
+    "geom:area_square_m":17156227305.106842,
     "geom:bbox":"-71.671925,-30.509804,-69.808981,-29.037697",
     "geom:latitude":-29.824185,
     "geom:longitude":-70.686685,
@@ -197,11 +197,12 @@
         "qs_pg:id":890663,
         "wd:id":"Q721224"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe71df0e16eca7775958e0b0bc60805d",
+    "wof:geomhash":"53cdff25ea52f027f76e2d0eeecac7c2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":102063091,
-    "wof:lastmodified":1690866770,
+    "wof:lastmodified":1695886491,
     "wof:name":"Elqui",
     "wof:parent_id":85682161,
     "wof:placetype":"county",

--- a/data/102/063/093/102063093.geojson
+++ b/data/102/063/093/102063093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.434586,
-    "geom:area_square_m":16438600975.071926,
+    "geom:area_square_m":16438600551.939577,
     "geom:bbox":"-70.291947,-22.880213,-68.85968,-21.284983",
     "geom:latitude":-22.068061,
     "geom:longitude":-69.60223,
@@ -178,11 +178,12 @@
         "hasc:id":"CL.AN.TO",
         "wd:id":"Q251448"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76ece6ad76e75681111f1905d4173608",
+    "wof:geomhash":"e009a7882ffbb7b513357509bd8cfcfa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":102063093,
-    "wof:lastmodified":1690866797,
+    "wof:lastmodified":1695886630,
     "wof:name":"Tocopilla",
     "wof:parent_id":85682175,
     "wof:placetype":"county",

--- a/data/102/063/095/102063095.geojson
+++ b/data/102/063/095/102063095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056442,
-    "geom:area_square_m":580799584.725361,
+    "geom:area_square_m":580799462.913469,
     "geom:bbox":"-71.120564,-33.803974,-70.778664,-33.509421",
     "geom:latitude":-33.675008,
     "geom:longitude":-70.935583,
@@ -161,11 +161,12 @@
         "wd:id":"Q721450",
         "wk:page":"Talagante"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c7e79cb888149c0bf44cc41377609cbf",
+    "wof:geomhash":"bb052d092168a1759a33e286e3465964",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":102063095,
-    "wof:lastmodified":1690866796,
+    "wof:lastmodified":1695886545,
     "wof:name":"Talagante",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/097/102063097.geojson
+++ b/data/102/063/097/102063097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.007552,
-    "geom:area_square_m":10077419831.069342,
+    "geom:area_square_m":10077419573.037321,
     "geom:bbox":"-72.187708,-36.543565,-70.567885,-35.417724",
     "geom:latitude":-36.013189,
     "geom:longitude":-71.426324,
@@ -179,11 +179,12 @@
         "wd:id":"Q721396",
         "wk:page":"Linares"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e773e5a27247a484b045702260ce5e0",
+    "wof:geomhash":"81daaf659f922c91999b690cfb202f84",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":102063097,
-    "wof:lastmodified":1690866771,
+    "wof:lastmodified":1695886623,
     "wof:name":"Linares",
     "wof:parent_id":85682149,
     "wof:placetype":"county",

--- a/data/102/063/099/102063099.geojson
+++ b/data/102/063/099/102063099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253546,
-    "geom:area_square_m":2640866272.113833,
+    "geom:area_square_m":2640866356.111586,
     "geom:bbox":"-71.055121,-32.980168,-70.21639,-32.253806",
     "geom:latitude":-32.611343,
     "geom:longitude":-70.665768,
@@ -170,11 +170,12 @@
         "wd:id":"Q721611",
         "wk:page":"San Felipe de Aconcagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ee023de4804707483aa3843d2543f3b",
+    "wof:geomhash":"65cbf01413e8f6be7f6ce672f5fce78f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":102063099,
-    "wof:lastmodified":1690866770,
+    "wof:lastmodified":1695886624,
     "wof:name":"San Felipe",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/101/102063101.geojson
+++ b/data/102/063/101/102063101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.382755,
-    "geom:area_square_m":13429500561.630827,
+    "geom:area_square_m":13429500757.738338,
     "geom:bbox":"-73.34113,-38.909573,-70.827381,-37.581733",
     "geom:latitude":-38.237673,
     "geom:longitude":-72.093642,
@@ -184,11 +184,12 @@
         "wd:id":"Q721462",
         "wk:page":"Malleco"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0c8f8cbe06e214bf8774fb6e6e92bb1",
+    "wof:geomhash":"6712ce29f98c5e39816d3cbaafd01387",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":102063101,
-    "wof:lastmodified":1690866783,
+    "wof:lastmodified":1695886506,
     "wof:name":"Malleco",
     "wof:parent_id":85682179,
     "wof:placetype":"county",

--- a/data/102/063/103/102063103.geojson
+++ b/data/102/063/103/102063103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1072,
-    "geom:area_square_m":1114120526.240106,
+    "geom:area_square_m":1114120617.849988,
     "geom:bbox":"-71.452206,-32.990638,-71.002061,-32.590921",
     "geom:latitude":-32.807163,
     "geom:longitude":-71.182886,
@@ -175,11 +175,12 @@
         "wd:id":"Q721567",
         "wk:page":"Quillota"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ac863ee1524b0ccecb70c55ea9cf905",
+    "wof:geomhash":"a16994f436c4d7b457c320f7a9d8b087",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":102063103,
-    "wof:lastmodified":1690866756,
+    "wof:lastmodified":1695886623,
     "wof:name":"Quillota",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/107/102063107.geojson
+++ b/data/102/063/107/102063107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.907372,
-    "geom:area_square_m":18342287571.991867,
+    "geom:area_square_m":18342287511.296566,
     "geom:bbox":"-73.518399,-39.636856,-71.373634,-38.320508",
     "geom:latitude":-38.947745,
     "geom:longitude":-72.405917,
@@ -187,11 +187,12 @@
         "qs_pg:id":1087905,
         "wd:id":"Q201237"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e69e2dfd62b2cd1db18d4d9a58c7132",
+    "wof:geomhash":"1966b7f8a9d8c6fa01800e0249f34e8c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":102063107,
-    "wof:lastmodified":1690866782,
+    "wof:lastmodified":1695886504,
     "wof:name":"Caut\u00edn",
     "wof:parent_id":85682179,
     "wof:placetype":"county",

--- a/data/102/063/109/102063109.geojson
+++ b/data/102/063/109/102063109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.318904,
-    "geom:area_square_m":13084873028.191925,
+    "geom:area_square_m":13084873001.683125,
     "geom:bbox":"-72.885837,-37.197621,-71.007303,-36.00556",
     "geom:latitude":-36.645579,
     "geom:longitude":-71.974533,
@@ -173,11 +173,12 @@
         "hasc:id":"CL.BI.NU",
         "wd:id":"Q721755"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75014cbc1a22f77cfe4da852f60bef0d",
+    "wof:geomhash":"20469e66cf127d5c4a7c26f53dcd34f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":102063109,
-    "wof:lastmodified":1690866781,
+    "wof:lastmodified":1695886501,
     "wof:name":"\u00d1uble",
     "wof:parent_id":85682155,
     "wof:placetype":"county",

--- a/data/102/063/111/102063111.geojson
+++ b/data/102/063/111/102063111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.985965,
-    "geom:area_square_m":9924441680.134766,
+    "geom:area_square_m":9924441410.603071,
     "geom:bbox":"-72.618302,-36.178334,-70.314772,-34.971431",
     "geom:latitude":-35.507072,
     "geom:longitude":-71.424386,
@@ -172,11 +172,12 @@
         "wd:id":"Q721653",
         "wk:page":"Talca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb11bb88b22d3fa506cbe4ae33e66d88",
+    "wof:geomhash":"39a21f809751d7e5e56c56e232a93ca5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":102063111,
-    "wof:lastmodified":1690866776,
+    "wof:lastmodified":1695886494,
     "wof:name":"Talca",
     "wof:parent_id":85682149,
     "wof:placetype":"county",

--- a/data/102/063/113/102063113.geojson
+++ b/data/102/063/113/102063113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.259159,
-    "geom:area_square_m":13375287440.361765,
+    "geom:area_square_m":13375287205.252182,
     "geom:bbox":"-71.719074,-31.434702,-70.180985,-30.208435",
     "geom:latitude":-30.788154,
     "geom:longitude":-70.961845,
@@ -185,11 +185,12 @@
         "wd:id":"Q63774",
         "wk:page":"Limar\u00ed"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c67d48f8ced57cc7cb77dd53af27f92c",
+    "wof:geomhash":"df60059b6e9566edf3aac81de25aca6e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":102063113,
-    "wof:lastmodified":1690866801,
+    "wof:lastmodified":1695886558,
     "wof:name":"Limar\u00ed",
     "wof:parent_id":85682161,
     "wof:placetype":"county",

--- a/data/102/063/115/102063115.geojson
+++ b/data/102/063/115/102063115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.016676,
-    "geom:area_square_m":9246591985.748575,
+    "geom:area_square_m":9246591768.417885,
     "geom:bbox":"-74.84898,-43.683253,-73.053459,-41.764919",
     "geom:latitude":-42.646291,
     "geom:longitude":-73.857776,
@@ -201,11 +201,12 @@
         "qs_pg:id":897113,
         "wd:id":"Q201267"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4016adbc7689e4fb7f67da25fdfd9027",
+    "wof:geomhash":"4f9ed4995babbf73050950dc2ef39e87",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":102063115,
-    "wof:lastmodified":1690866798,
+    "wof:lastmodified":1695886546,
     "wof:name":"Chiloe",
     "wof:parent_id":85682233,
     "wof:placetype":"county",

--- a/data/102/063/117/102063117.geojson
+++ b/data/102/063/117/102063117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196811,
-    "geom:area_square_m":2032249865.552166,
+    "geom:area_square_m":2032249899.85766,
     "geom:bbox":"-70.955136,-33.627754,-70.175868,-33.096427",
     "geom:latitude":-33.375947,
     "geom:longitude":-70.526336,
@@ -206,11 +206,12 @@
         "wd:id":"Q45632",
         "wk:page":"Santiago"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1c6736fb6b487892a44f7c56c7afffd",
+    "wof:geomhash":"de3625eec331fb64b6fc3dc223607e65",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":102063117,
-    "wof:lastmodified":1690866779,
+    "wof:lastmodified":1695886626,
     "wof:name":"Santiago",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/119/102063119.geojson
+++ b/data/102/063/119/102063119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109221,
-    "geom:area_square_m":1122362627.918128,
+    "geom:area_square_m":1122362576.005717,
     "geom:bbox":"-70.988963,-33.988669,-70.475152,-33.524076",
     "geom:latitude":-33.793494,
     "geom:longitude":-70.752005,
@@ -170,11 +170,12 @@
         "wd:id":"Q721450",
         "wk:page":"Maipo"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"457b4f239369e7e25018766310a36939",
+    "wof:geomhash":"7cf57fc352c19eeded183a4ec63d2efe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":102063119,
-    "wof:lastmodified":1690866779,
+    "wof:lastmodified":1695886498,
     "wof:name":"Maipo",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/121/102063121.geojson
+++ b/data/102/063/121/102063121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.987076,
-    "geom:area_square_m":9248008370.74741,
+    "geom:area_square_m":9248008997.287359,
     "geom:bbox":"-73.947252,-41.119254,-71.825198,-40.236539",
     "geom:latitude":-40.737837,
     "geom:longitude":-73.054624,
@@ -172,11 +172,12 @@
         "hasc:id":"CL.LG.OS",
         "wd:id":"Q721503"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b704a20ef66209d26463dde9b3ba286",
+    "wof:geomhash":"8607b0e3d43466f453b611d7404494b7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":102063121,
-    "wof:lastmodified":1690866778,
+    "wof:lastmodified":1695886498,
     "wof:name":"Osorno",
     "wof:parent_id":85682233,
     "wof:placetype":"county",

--- a/data/102/063/127/102063127.geojson
+++ b/data/102/063/127/102063127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.378973,
-    "geom:area_square_m":11730964036.006523,
+    "geom:area_square_m":11730964313.290001,
     "geom:bbox":"-73.410946,-47.09409,-71.643373,-45.920276",
     "geom:latitude":-46.528822,
     "geom:longitude":-72.535245,
@@ -182,11 +182,12 @@
         "wd:id":"Q721242",
         "wk:page":"General Carrera Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"024bde286ba3f18fc815c9975f163fa7",
+    "wof:geomhash":"e1b40cd6d993867ff8a8be47cfb68f2d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":102063127,
-    "wof:lastmodified":1690866776,
+    "wof:lastmodified":1695886496,
     "wof:name":"General Carrera",
     "wof:parent_id":85682189,
     "wof:placetype":"county",

--- a/data/102/063/129/102063129.geojson
+++ b/data/102/063/129/102063129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301438,
-    "geom:area_square_m":3018652389.297681,
+    "geom:area_square_m":3018652164.04825,
     "geom:bbox":"-72.7859,-36.261367,-71.976233,-35.541012",
     "geom:latitude":-35.916809,
     "geom:longitude":-72.355878,
@@ -172,11 +172,12 @@
         "wd:id":"Q201176",
         "wk:page":"Cauquenes"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1d06716e677ca2eb37b0ebf2bad2a2f",
+    "wof:geomhash":"6b26f1971e07cf1841897e0c6ec4289e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":102063129,
-    "wof:lastmodified":1690866775,
+    "wof:lastmodified":1695886625,
     "wof:name":"Cauquenes",
     "wof:parent_id":85682149,
     "wof:placetype":"county",

--- a/data/102/063/131/102063131.geojson
+++ b/data/102/063/131/102063131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.692136,
-    "geom:area_square_m":42076191694.0494,
+    "geom:area_square_m":42076192776.139542,
     "geom:bbox":"-69.194012,-24.326417,-67.003011,-20.940313",
     "geom:latitude":-22.815413,
     "geom:longitude":-68.202889,
@@ -194,11 +194,12 @@
         "wd:id":"Q201349",
         "wk:page":"El Loa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b008f1dfccbc2f378474a8605589fa2",
+    "wof:geomhash":"5bfc14ffd31dce2f1715db1641dbd29a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":102063131,
-    "wof:lastmodified":1690866780,
+    "wof:lastmodified":1695886503,
     "wof:name":"El Loa",
     "wof:parent_id":85682175,
     "wof:placetype":"county",

--- a/data/102/063/133/102063133.geojson
+++ b/data/102/063/133/102063133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.249904,
-    "geom:area_square_m":24947010271.038033,
+    "geom:area_square_m":24947010251.634827,
     "geom:bbox":"-70.724981,-26.940568,-68.361236,-25.287753",
     "geom:latitude":-26.268525,
     "geom:longitude":-69.453099,
@@ -161,11 +161,12 @@
         "hasc:id":"CL.AT.CR",
         "wd:id":"Q201256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"231266cdbd1a5d47a9b137c8f4c18ed0",
+    "wof:geomhash":"ecefaedbdd3df50c205d9beee7468b95",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":102063133,
-    "wof:lastmodified":1690866757,
+    "wof:lastmodified":1695886459,
     "wof:name":"Cha\u00f1aral",
     "wof:parent_id":85682139,
     "wof:placetype":"county",

--- a/data/102/063/135/102063135.geojson
+++ b/data/102/063/135/102063135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.594726,
-    "geom:area_square_m":14784290489.712139,
+    "geom:area_square_m":14784290421.533981,
     "geom:bbox":"-73.93979,-42.189532,-71.724482,-40.794195",
     "geom:latitude":-41.430936,
     "geom:longitude":-72.713644,
@@ -196,11 +196,12 @@
         "wd:id":"Q721408",
         "wk:page":"Llanquihue"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4861491b9a8256bcc89703fd99be48f3",
+    "wof:geomhash":"bf78fa65d19dae6e9d44d0491445185c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":102063135,
-    "wof:lastmodified":1690866755,
+    "wof:lastmodified":1695886451,
     "wof:name":"Llanquihue",
     "wof:parent_id":85682233,
     "wof:placetype":"county",

--- a/data/102/063/137/102063137.geojson
+++ b/data/102/063/137/102063137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.536655,
-    "geom:area_square_m":5520400511.58091,
+    "geom:area_square_m":5520400625.465402,
     "geom:bbox":"-70.655887,-34.290669,-69.770032,-33.051444",
     "geom:latitude":-33.703983,
     "geom:longitude":-70.13713,
@@ -188,11 +188,12 @@
         "wd:id":"Q201331",
         "wk:page":"Cordillera"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aff95ef54d1e4bdb8fe646c82ebaea65",
+    "wof:geomhash":"760bf7ed85d8ace2952361fa0f924930",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":102063137,
-    "wof:lastmodified":1690866784,
+    "wof:lastmodified":1695886629,
     "wof:name":"Cordillera",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/139/102063139.geojson
+++ b/data/102/063/139/102063139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.296207,
-    "geom:area_square_m":3077658586.495552,
+    "geom:area_square_m":3077658941.223794,
     "geom:bbox":"-70.767857,-33.187568,-69.977481,-32.430219",
     "geom:latitude":-32.829815,
     "geom:longitude":-70.338917,
@@ -184,11 +184,12 @@
         "wd:id":"Q721424",
         "wk:page":"Los Andes"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"107689ab72e73010fd8ef46655f51139",
+    "wof:geomhash":"b27d6fb825adf0f0c6da831d77d7487f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":102063139,
-    "wof:lastmodified":1690866783,
+    "wof:lastmodified":1695886626,
     "wof:name":"Los Andes",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/143/102063143.geojson
+++ b/data/102/063/143/102063143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.976594,
-    "geom:area_square_m":32649778699.932026,
+    "geom:area_square_m":32649778183.329525,
     "geom:bbox":"-71.143592,-28.643587,-68.264216,-26.642622",
     "geom:latitude":-27.488863,
     "geom:longitude":-69.870438,
@@ -185,11 +185,12 @@
         "wd:id":"Q74292",
         "wk:page":"Copiap\u00f3"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"686b438dff4c7fc7e5c5954694c66123",
+    "wof:geomhash":"d89195f54fb33ed26ccf2bba84848bd0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":102063143,
-    "wof:lastmodified":1690866777,
+    "wof:lastmodified":1695886496,
     "wof:name":"Copiap\u00f3",
     "wof:parent_id":85682139,
     "wof:placetype":"county",

--- a/data/102/063/145/102063145.geojson
+++ b/data/102/063/145/102063145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259349,
-    "geom:area_square_m":2997920078.555822,
+    "geom:area_square_m":2997920343.580209,
     "geom:bbox":"-70.207016,-21.438522,-69.824678,-20.048233",
     "geom:latitude":-20.795188,
     "geom:longitude":-70.035214,
@@ -181,11 +181,12 @@
         "wd:id":"Q251456",
         "wk:page":"Iquique"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c533f442e2112d337ca6f5d7253436ba",
+    "wof:geomhash":"dc4de88cd1dbd778f6e86df972696378",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":102063145,
-    "wof:lastmodified":1690866774,
+    "wof:lastmodified":1695886492,
     "wof:name":"Iquique",
     "wof:parent_id":85682245,
     "wof:placetype":"county",

--- a/data/102/063/147/102063147.geojson
+++ b/data/102/063/147/102063147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.720587,
-    "geom:area_square_m":7289293690.18773,
+    "geom:area_square_m":7289293580.551557,
     "geom:bbox":"-72.186898,-35.628026,-70.35798,-34.684574",
     "geom:latitude":-35.10608,
     "geom:longitude":-71.119543,
@@ -173,11 +173,12 @@
         "hasc:id":"CL.ML.CU",
         "wd:id":"Q201338"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b8ce1be94898ed437f22c65ecd869b6",
+    "wof:geomhash":"b2bb021353a6777515e5d5dada7d23c2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":102063147,
-    "wof:lastmodified":1690866801,
+    "wof:lastmodified":1695886561,
     "wof:name":"Curic\u00f3",
     "wof:parent_id":85682149,
     "wof:placetype":"county",

--- a/data/102/063/149/102063149.geojson
+++ b/data/102/063/149/102063149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322174,
-    "geom:area_square_m":3289924588.64734,
+    "geom:area_square_m":3289924616.250714,
     "geom:bbox":"-72.056454,-34.84083,-71.452865,-33.902724",
     "geom:latitude":-34.326013,
     "geom:longitude":-71.781685,
@@ -202,11 +202,12 @@
         "wd:id":"Q201163",
         "wk:page":"Cardenal Caro"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5774d7b678e85e30b2dbfbfac577132",
+    "wof:geomhash":"7a06cf287d60b9fa35fe9129f523f80d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":102063149,
-    "wof:lastmodified":1690866802,
+    "wof:lastmodified":1695886562,
     "wof:name":"Cardenal Caro",
     "wof:parent_id":85682165,
     "wof:placetype":"county",

--- a/data/102/063/151/102063151.geojson
+++ b/data/102/063/151/102063151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.53358,
-    "geom:area_square_m":15035946402.919905,
+    "geom:area_square_m":15035946367.484528,
     "geom:bbox":"-73.070841,-38.314499,-70.984933,-36.895739",
     "geom:latitude":-37.540805,
     "geom:longitude":-71.927202,
@@ -191,11 +191,12 @@
         "hasc:id":"CL.BI.BI",
         "wd:id":"Q201131"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01b5e36b786b0bca660f2bc4b5e62bfa",
+    "wof:geomhash":"4c218262d2045a98a4180f803511b0a6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":102063151,
-    "wof:lastmodified":1690866758,
+    "wof:lastmodified":1695886460,
     "wof:name":"B\u00edo-B\u00edo",
     "wof:parent_id":85682155,
     "wof:placetype":"county",

--- a/data/102/063/153/102063153.geojson
+++ b/data/102/063/153/102063153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.559739,
-    "geom:area_square_m":5474094871.819531,
+    "geom:area_square_m":5474094756.340466,
     "geom:bbox":"-73.961443,-38.492464,-72.981197,-37.146452",
     "geom:latitude":-37.728275,
     "geom:longitude":-73.346011,
@@ -190,11 +190,12 @@
         "hasc:id":"CL.BI.AU",
         "wd:id":"Q201109"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f585ec23dd24a32f650dc7cee44d731",
+    "wof:geomhash":"6a387d21641dd5620d991e37bbc74a53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":102063153,
-    "wof:lastmodified":1690866779,
+    "wof:lastmodified":1695886500,
     "wof:name":"Arauco",
     "wof:parent_id":85682155,
     "wof:placetype":"county",

--- a/data/102/063/155/102063155.geojson
+++ b/data/102/063/155/102063155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.734568,
-    "geom:area_square_m":7504909045.63555,
+    "geom:area_square_m":7504908835.227894,
     "geom:bbox":"-71.576067,-34.703798,-70.00916,-33.850573",
     "geom:latitude":-34.28397,
     "geom:longitude":-70.710983,
@@ -193,11 +193,12 @@
         "wd:id":"Q201144",
         "wk:page":"Cachapoal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c7647a8f013b21832e4bda3f85e1e74b",
+    "wof:geomhash":"fafb0cbc568db81f08665fa50d18d1ec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":102063155,
-    "wof:lastmodified":1690866782,
+    "wof:lastmodified":1695886505,
     "wof:name":"Cachapoal",
     "wof:parent_id":85682165,
     "wof:placetype":"county",

--- a/data/102/063/157/102063157.geojson
+++ b/data/102/063/157/102063157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54621,
-    "geom:area_square_m":5552483236.677835,
+    "geom:area_square_m":5552483066.336429,
     "geom:bbox":"-71.859937,-35.006489,-70.249097,-34.359361",
     "geom:latitude":-34.703836,
     "geom:longitude":-71.064204,
@@ -196,11 +196,12 @@
         "wd:id":"Q201304",
         "wk:page":"Colchagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7607f1cad8d718539f192a362f5c653e",
+    "wof:geomhash":"dc45a90057fe608c5f7cd2f4f85bf8e1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":102063157,
-    "wof:lastmodified":1690866757,
+    "wof:lastmodified":1695886455,
     "wof:name":"Colchagua",
     "wof:parent_id":85682165,
     "wof:placetype":"county",

--- a/data/102/063/161/102063161.geojson
+++ b/data/102/063/161/102063161.geojson
@@ -727,6 +727,7 @@
     "wof:concordances":{
         "hasc:id":"CL.VS.IP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -741,7 +742,7 @@
         }
     ],
     "wof:id":102063161,
-    "wof:lastmodified":1694492485,
+    "wof:lastmodified":1695886456,
     "wof:name":"Valpara\u00edso",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/165/102063165.geojson
+++ b/data/102/063/165/102063165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.723212,
-    "geom:area_square_m":8470192645.924322,
+    "geom:area_square_m":8470193033.638857,
     "geom:bbox":"-70.376868,-19.189358,-69.068332,-18.110527",
     "geom:latitude":-18.706187,
     "geom:longitude":-69.855828,
@@ -175,11 +175,12 @@
         "hasc:id":"CL.AP.AR",
         "wd:id":"Q201119"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7034c664c1884a863eefcb620fe51e53",
+    "wof:geomhash":"4214da2b19e256ac10d133d610834664",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":102063165,
-    "wof:lastmodified":1690866780,
+    "wof:lastmodified":1695886503,
     "wof:name":"Arica",
     "wof:parent_id":1108804709,
     "wof:placetype":"county",

--- a/data/102/063/167/102063167.geojson
+++ b/data/102/063/167/102063167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147378,
-    "geom:area_square_m":1517246341.376518,
+    "geom:area_square_m":1517246314.751729,
     "geom:bbox":"-71.843249,-33.956064,-71.328032,-33.251942",
     "geom:latitude":-33.635865,
     "geom:longitude":-71.571727,
@@ -192,11 +192,12 @@
         "wd:id":"Q721594",
         "wk:page":"San Antonio"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c7d8d4976d72d0630a35c671f64401c",
+    "wof:geomhash":"6f6e4cd8cc5402db5c62a50e05396f8f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":102063167,
-    "wof:lastmodified":1690866758,
+    "wof:lastmodified":1695886625,
     "wof:name":"San Antonio",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/102/063/169/102063169.geojson
+++ b/data/102/063/169/102063169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.658832,
-    "geom:area_square_m":14992530281.068739,
+    "geom:area_square_m":14992530336.96279,
     "geom:bbox":"-73.104924,-44.067119,-71.582377,-41.713146",
     "geom:latitude":-43.033163,
     "geom:longitude":-72.385891,
@@ -181,11 +181,12 @@
         "wd:id":"Q721535",
         "wk:page":"Palena"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fef9b7a8412bc4d8f949b65fe1aedcd2",
+    "wof:geomhash":"796533d52e59b9e455a2047421530f7d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":102063169,
-    "wof:lastmodified":1690866759,
+    "wof:lastmodified":1695886462,
     "wof:name":"Palena",
     "wof:parent_id":85682233,
     "wof:placetype":"county",

--- a/data/102/063/171/102063171.geojson
+++ b/data/102/063/171/102063171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.350997,
-    "geom:area_square_m":3468303175.928588,
+    "geom:area_square_m":3468303357.285161,
     "geom:bbox":"-73.556074,-37.451174,-72.538448,-36.442605",
     "geom:latitude":-36.953139,
     "geom:longitude":-72.918365,
@@ -381,11 +381,12 @@
         "wd:id":"Q40008",
         "wk:page":"Concepci\u00f3n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88c5cd9f7ba6a371fee9e6b2bfe1baf1",
+    "wof:geomhash":"041447af81e1ef74b72eb8d14f8ef20d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -395,7 +396,7 @@
         }
     ],
     "wof:id":102063171,
-    "wof:lastmodified":1690866803,
+    "wof:lastmodified":1695886563,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":85682155,
     "wof:placetype":"county",

--- a/data/102/063/173/102063173.geojson
+++ b/data/102/063/173/102063173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200315,
-    "geom:area_square_m":2073951236.360099,
+    "geom:area_square_m":2073951067.178837,
     "geom:bbox":"-71.029324,-33.385353,-70.373573,-32.922479",
     "geom:latitude":-33.143288,
     "geom:longitude":-70.754198,
@@ -167,11 +167,12 @@
         "wd:id":"Q201247",
         "wk:page":"Chacabuco"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"002844f75882ea90d99aa754894c65df",
+    "wof:geomhash":"39bf7e260ec2ccdd3de9b9cf97556d60",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":102063173,
-    "wof:lastmodified":1690866773,
+    "wof:lastmodified":1695886626,
     "wof:name":"Chacabuco",
     "wof:parent_id":85682207,
     "wof:placetype":"county",

--- a/data/102/063/175/102063175.geojson
+++ b/data/102/063/175/102063175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.680575,
-    "geom:area_square_m":18220971002.8983,
+    "geom:area_square_m":18220971071.697002,
     "geom:bbox":"-71.528039,-29.535151,-69.692107,-27.962484",
     "geom:latitude":-28.7365,
     "geom:longitude":-70.591586,
@@ -196,11 +196,12 @@
         "wd:id":"Q74294",
         "wk:page":"Huasco"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf4278b3c2ebe3937f6ea4b17c5bbb66",
+    "wof:geomhash":"c87b67949d5acde50f46afef0e1f33d3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":102063175,
-    "wof:lastmodified":1690866777,
+    "wof:lastmodified":1695886627,
     "wof:name":"Huasco",
     "wof:parent_id":85682139,
     "wof:placetype":"county",

--- a/data/102/063/179/102063179.geojson
+++ b/data/102/063/179/102063179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.96445,
-    "geom:area_square_m":10144841142.71966,
+    "geom:area_square_m":10144841090.82946,
     "geom:bbox":"-71.647548,-32.282156,-70.208086,-31.141673",
     "geom:latitude":-31.713678,
     "geom:longitude":-71.017921,
@@ -178,11 +178,12 @@
         "hasc:id":"CL.CO.CH",
         "wd:id":"Q63916"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcc45f98a2622e90d3aa22666cd542de",
+    "wof:geomhash":"ed0203100652545d74f42544c79c1d69",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":102063179,
-    "wof:lastmodified":1690866800,
+    "wof:lastmodified":1695886559,
     "wof:name":"Choapa",
     "wof:parent_id":85682161,
     "wof:placetype":"county",

--- a/data/102/063/181/102063181.geojson
+++ b/data/102/063/181/102063181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.700347,
-    "geom:area_square_m":8223694595.321762,
+    "geom:area_square_m":8223694527.465679,
     "geom:bbox":"-69.842265,-19.03101,-68.913362,-17.498426",
     "geom:latitude":-18.260074,
     "geom:longitude":-69.385392,
@@ -181,11 +181,12 @@
         "wd:id":"Q287619",
         "wk:page":"Parinacota"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec75978af71078c430ba1995fd66380e",
+    "wof:geomhash":"fbdac3a7c5ae9a85c4aad48747e5083d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":102063181,
-    "wof:lastmodified":1690866777,
+    "wof:lastmodified":1695886498,
     "wof:name":"Parinacota",
     "wof:parent_id":1108804709,
     "wof:placetype":"county",

--- a/data/102/063/183/102063183.geojson
+++ b/data/102/063/183/102063183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.961801,
-    "geom:area_square_m":9145412146.061167,
+    "geom:area_square_m":9145412769.708721,
     "geom:bbox":"-73.708847,-40.117913,-71.58773,-39.287737",
     "geom:latitude":-39.736992,
     "geom:longitude":-72.58336,
@@ -159,11 +159,12 @@
         "hasc:id":"CL.LR.VD",
         "wd:id":"Q721733"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8160d3f103ab7dd0ab081845a1996cc9",
+    "wof:geomhash":"bad2dc97cf39269def0dc7b680b6cb8a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":102063183,
-    "wof:lastmodified":1690866799,
+    "wof:lastmodified":1695886554,
     "wof:name":"Valdivia",
     "wof:parent_id":85682171,
     "wof:placetype":"county",

--- a/data/102/063/185/102063185.geojson
+++ b/data/102/063/185/102063185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.017042,
-    "geom:area_square_m":22106248354.999928,
+    "geom:area_square_m":22106246206.908607,
     "geom:bbox":"-71.1106,-54.747941,-68.604781,-52.452953",
     "geom:latitude":-53.658691,
     "geom:longitude":-69.454656,
@@ -188,11 +188,12 @@
         "wd:id":"Q721689",
         "wk:page":"Tierra del Fuego"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5cb51c83ee4280d1a41e5048f39ff93",
+    "wof:geomhash":"eda2ac4c57cfedd1b92e7ef8a8f82e91",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":102063185,
-    "wof:lastmodified":1690866803,
+    "wof:lastmodified":1695886631,
     "wof:name":"Tierra del Fuego",
     "wof:parent_id":85682211,
     "wof:placetype":"county",

--- a/data/102/063/187/102063187.geojson
+++ b/data/102/063/187/102063187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.226566,
-    "geom:area_square_m":45331211565.109665,
+    "geom:area_square_m":45331211542.27832,
     "geom:bbox":"-75.646118,-47.054794,-71.944519,-43.641613",
     "geom:latitude":-45.451999,
     "geom:longitude":-73.564494,
@@ -179,12 +179,13 @@
         "hasc:id":"CL.AI.AI",
         "wd:id":"Q201126"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "meso-reversegeo",
         "meso"
     ],
-    "wof:geomhash":"64f4acb5c805c0af188e717b712653bd",
+    "wof:geomhash":"19e679d2a03dca75b351d0bb6d04c829",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":102063187,
-    "wof:lastmodified":1690866772,
+    "wof:lastmodified":1695886272,
     "wof:name":"Ays\u00e9n",
     "wof:parent_id":85682189,
     "wof:placetype":"county",

--- a/data/102/063/189/102063189.geojson
+++ b/data/102/063/189/102063189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.960101,
-    "geom:area_square_m":9057703496.748837,
+    "geom:area_square_m":9057703387.571384,
     "geom:bbox":"-73.727678,-40.681161,-71.656044,-39.896399",
     "geom:latitude":-40.274078,
     "geom:longitude":-72.559046,
@@ -145,11 +145,12 @@
         "wd:id":"Q353230",
         "wk:page":"Ranco"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d4b556ef85143a8a3aa176fbef04daba",
+    "wof:geomhash":"d4f81338d9f59d803d8c1245bc02ddb3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":102063189,
-    "wof:lastmodified":1690866774,
+    "wof:lastmodified":1695886493,
     "wof:name":"Ranco",
     "wof:parent_id":85682171,
     "wof:placetype":"county",

--- a/data/110/872/174/1/1108721741.geojson
+++ b/data/110/872/174/1/1108721741.geojson
@@ -53,7 +53,10 @@
         85667991
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"0"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"CL",
     "wof:created":1476220470,
     "wof:geomhash":"2b06eced3cc126ed9003ffbb8f4e18d0",
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108721741,
-    "wof:lastmodified":1694492899,
+    "wof:lastmodified":1695886435,
     "wof:name":"Zona sin demarcar",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/872/174/7/1108721747.geojson
+++ b/data/110/872/174/7/1108721747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111804,
-    "geom:area_square_m":1158275976.580821,
+    "geom:area_square_m":1158275799.555416,
     "geom:bbox":"-71.493386,-33.24653,-70.992502,-32.917597",
     "geom:latitude":-33.08876,
     "geom:longitude":-71.2381,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"CL.VS.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:created":1476220495,
-    "wof:geomhash":"a4c0d0ac4dfa7be9722a85ce51d0f804",
+    "wof:geomhash":"7d4d24149df7b323f0b2e58dab2e4c6d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108721747,
-    "wof:lastmodified":1627522004,
+    "wof:lastmodified":1695886490,
     "wof:name":"Marga Marga",
     "wof:parent_id":85682143,
     "wof:placetype":"county",

--- a/data/110/878/642/1/1108786421.geojson
+++ b/data/110/878/642/1/1108786421.geojson
@@ -79,6 +79,7 @@
         "hasc:id":"CL.VS.IP",
         "qs_pg:id":579646
     },
+    "wof:concordances_official":"hasc:id",
     "wof:controlled":[
         "wof:parent_id"
     ],
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108786421,
-    "wof:lastmodified":1694492850,
+    "wof:lastmodified":1695886304,
     "wof:name":"Isla de Pascua",
     "wof:parent_id":85633057,
     "wof:placetype":"county",

--- a/data/110/880/470/9/1108804709.geojson
+++ b/data/110/880/470/9/1108804709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.423559,
-    "geom:area_square_m":16693887241.23823,
+    "geom:area_square_m":16693887561.099564,
     "geom:bbox":"-70.376868,-19.189358,-68.913362,-17.498426",
     "geom:latitude":-18.486713,
     "geom:longitude":-69.624388,
@@ -318,12 +318,14 @@
         "gn:id":6693562,
         "gp:id":56043702,
         "hasc:id":"CL.AP",
+        "iso:code":"CL-AP",
         "iso:id":"CL-AP",
         "wd:id":"Q2109"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:created":1485297129,
-    "wof:geomhash":"e5d287e526ec63c469bb5db99a2d8876",
+    "wof:geomhash":"8dc09fe5f31d731660dbe94fdd130eb4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866948,
+    "wof:lastmodified":1695884785,
     "wof:name":"Arica y Parinacota",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/330/57/85633057.geojson
+++ b/data/856/330/57/85633057.geojson
@@ -1243,6 +1243,7 @@
         "hasc:id":"CL",
         "icao:code":"CC",
         "ioc:id":"CHI",
+        "iso:code":"CL",
         "itu:id":"CHL",
         "m49:code":"152",
         "marc:id":"cl",
@@ -1253,6 +1254,7 @@
         "wd:id":"Q298",
         "wmo:id":"CH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:country_alpha3":"CHL",
     "wof:geom_alt":[
@@ -1273,7 +1275,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1694639587,
+    "wof:lastmodified":1695881248,
     "wof:name":"Chile",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/821/39/85682139.geojson
+++ b/data/856/821/39/85682139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.907073,
-    "geom:area_square_m":75817759973.870499,
+    "geom:area_square_m":75817759506.661743,
     "geom:bbox":"-71.528039,-29.535151,-68.264216,-25.287753",
     "geom:latitude":-27.394917,
     "geom:longitude":-69.909959,
@@ -355,15 +355,17 @@
         "gn:id":3899191,
         "gp:id":2345022,
         "hasc:id":"CL.AT",
+        "iso:code":"CL-AT",
         "iso:id":"CL-AT",
         "unlc:id":"CL-AT",
         "wd:id":"Q2120"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f410001a3e02fb2b5b11e0b866402c22",
+    "wof:geomhash":"e2179a812db3dfe1f84f1ac213ce681e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -378,7 +380,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866931,
+    "wof:lastmodified":1695884491,
     "wof:name":"De Atacama",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/43/85682143.geojson
+++ b/data/856/821/43/85682143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.56512,
-    "geom:area_square_m":16277703495.108854,
+    "geom:area_square_m":16277703909.52458,
     "geom:bbox":"-109.45656,-33.956064,-69.977481,-27.053618",
     "geom:latitude":-32.737694,
     "geom:longitude":-71.367954,
@@ -375,14 +375,16 @@
         "gn:id":3868621,
         "gp:id":2345018,
         "hasc:id":"CL.VS",
+        "iso:code":"CL-VS",
         "iso:id":"CL-VS",
         "wd:id":"Q219458"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"467ed8d7e1bfe43a4fbe0ec41fca3b5e",
+    "wof:geomhash":"a884489c99706e0a908054526d7c6c47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -397,7 +399,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866929,
+    "wof:lastmodified":1695884566,
     "wof:name":"De Valparaiso",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/49/85682149.geojson
+++ b/data/856/821/49/85682149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.015542,
-    "geom:area_square_m":30309807590.425941,
+    "geom:area_square_m":30309806729.824448,
     "geom:bbox":"-72.7859,-36.543565,-70.314772,-34.684574",
     "geom:latitude":-35.621314,
     "geom:longitude":-71.445302,
@@ -371,15 +371,17 @@
         "gn:id":3880306,
         "gp:id":2345028,
         "hasc:id":"CL.ML",
+        "iso:code":"CL-ML",
         "iso:id":"CL-ML",
         "unlc:id":"CL-ML",
         "wd:id":"Q2166"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"197baec7c110c3a27be49a38a451dff1",
+    "wof:geomhash":"e7fd680a5fdbf476e63ba548b5093e5f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -394,7 +396,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866935,
+    "wof:lastmodified":1695884565,
     "wof:name":"Del Maule",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/55/85682155.geojson
+++ b/data/856/821/55/85682155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.76322,
-    "geom:area_square_m":37063217478.574814,
+    "geom:area_square_m":37063217481.339355,
     "geom:bbox":"-73.961443,-38.492464,-70.984933,-36.00556",
     "geom:latitude":-37.200125,
     "geom:longitude":-72.247269,
@@ -425,14 +425,16 @@
     "wof:concordances":{
         "fips:code":"CI06",
         "hasc:id":"CL.BI",
+        "iso:code":"CL-BI",
         "iso:id":"CL-BI",
         "wd:id":"Q2170"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8607019d17f3e2b7e87201987bd36db2",
+    "wof:geomhash":"6e0b208674a6cd35cb423a3a7afc925c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -447,7 +449,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866932,
+    "wof:lastmodified":1695884578,
     "wof:name":"Del Bio-Bio",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/61/85682161.geojson
+++ b/data/856/821/61/85682161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.822915,
-    "geom:area_square_m":40676356673.603432,
+    "geom:area_square_m":40676355601.196365,
     "geom:bbox":"-71.719074,-32.282156,-69.808981,-29.037697",
     "geom:latitude":-30.618373,
     "geom:longitude":-70.86088,
@@ -358,15 +358,17 @@
         "gn:id":3893623,
         "gp:id":2345024,
         "hasc:id":"CL.CO",
+        "iso:code":"CL-CO",
         "iso:id":"CL-CO",
         "unlc:id":"CL-CO",
         "wd:id":"Q2121"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"750401e1944b5b3c8b9804adec26c68e",
+    "wof:geomhash":"741de0053b8560fe3d6305c01ed9b0d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -381,7 +383,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866923,
+    "wof:lastmodified":1695884486,
     "wof:name":"De Coquimbo",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/65/85682165.geojson
+++ b/data/856/821/65/85682165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.602952,
-    "geom:area_square_m":16347316518.216087,
+    "geom:area_square_m":16347316518.213947,
     "geom:bbox":"-72.056454,-35.006489,-70.00916,-33.850573",
     "geom:latitude":-34.435491,
     "geom:longitude":-71.046543,
@@ -346,14 +346,16 @@
         "gn:id":3883281,
         "gp:id":2345025,
         "hasc:id":"CL.LI",
+        "iso:code":"CL-LI",
         "iso:id":"CL-LI",
         "wd:id":"Q2133"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57f254b2c2747ae6fd96a264b40745dc",
+    "wof:geomhash":"e98bbf1b49b0cae2cf4c98e511506511",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866930,
+    "wof:lastmodified":1695884492,
     "wof:name":"Del Libertador B Ohiggins",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/71/85682171.geojson
+++ b/data/856/821/71/85682171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.921902,
-    "geom:area_square_m":18203115642.715652,
+    "geom:area_square_m":18203116156.66024,
     "geom:bbox":"-73.727678,-40.681161,-71.58773,-39.287737",
     "geom:latitude":-40.005298,
     "geom:longitude":-72.571214,
@@ -300,14 +300,16 @@
     "wof:concordances":{
         "fips:code":"CI17",
         "hasc:id":"CL.LR",
+        "iso:code":"CL-LR",
         "iso:id":"CL-LR",
         "wd:id":"Q2177"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c267ef54db5c15625635a97e3c68d6fa",
+    "wof:geomhash":"6d7fdd4dc57fce54014d6afd59d2d867",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866934,
+    "wof:lastmodified":1695884493,
     "wof:name":"De Los Rios",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/75/85682175.geojson
+++ b/data/856/821/75/85682175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.152067,
-    "geom:area_square_m":126396481842.34021,
+    "geom:area_square_m":126396482115.714279,
     "geom:bbox":"-70.738609,-26.057821,-67.003011,-20.940313",
     "geom:latitude":-23.53615,
     "geom:longitude":-69.120973,
@@ -361,15 +361,17 @@
         "gn:id":3899537,
         "gp:id":2345020,
         "hasc:id":"CL.AN",
+        "iso:code":"CL-AN",
         "iso:id":"CL-AN",
         "unlc:id":"CL-AN",
         "wd:id":"Q2118"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e1fa6260d93c08c3a4f8b8f27daff4c",
+    "wof:geomhash":"7976dd6ce9588ce22130875d082c9a8b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866927,
+    "wof:lastmodified":1695884491,
     "wof:name":"De Antofagasta",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/79/85682179.geojson
+++ b/data/856/821/79/85682179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.290127,
-    "geom:area_square_m":31771788133.299786,
+    "geom:area_square_m":31771788247.298527,
     "geom:bbox":"-73.518399,-39.636856,-70.827381,-37.581733",
     "geom:latitude":-38.64932,
     "geom:longitude":-72.274676,
@@ -379,14 +379,16 @@
         "gn:id":3899463,
         "gp:id":2345021,
         "hasc:id":"CL.AR",
+        "iso:code":"CL-AR",
         "iso:id":"CL-AR",
         "wd:id":"Q2176"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67718910ef7c4279ce114a20ae25e9ca",
+    "wof:geomhash":"90818876b880be17f904106dcff82b44",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -401,7 +403,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866933,
+    "wof:lastmodified":1695884568,
     "wof:name":"De La Araucania",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/83/85682183.geojson
+++ b/data/856/821/83/85682183.geojson
@@ -51,7 +51,10 @@
         85632505
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"CL-CHS"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CL",
     "wof:geomhash":"d2845075df95ae07a7a37f975231b41f",
     "wof:hierarchy":[
@@ -73,7 +76,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694493237,
+    "wof:lastmodified":1695884738,
     "wof:name":"Andean Southern Ice Field (Campo de Hielo Sur)",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/821/89/85682189.geojson
+++ b/data/856/821/89/85682189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.496931,
-    "geom:area_square_m":106487932179.501129,
+    "geom:area_square_m":106487935882.014923,
     "geom:bbox":"-75.646118,-49.150002,-71.09063,-43.641613",
     "geom:latitude":-46.422938,
     "geom:longitude":-73.254315,
@@ -354,14 +354,16 @@
         "gn:id":3900333,
         "gp:id":2345019,
         "hasc:id":"CL.AI",
+        "iso:code":"CL-AI",
         "iso:id":"CL-AI",
         "wd:id":"Q2181"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"7d44339a4fffe5198d0f2146e165c3f6",
+    "wof:geomhash":"16ed970861f9f63599023dc3677a9b84",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -376,7 +378,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866925,
+    "wof:lastmodified":1695884487,
     "wof:name":"De Aisen",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/822/07/85682207.geojson
+++ b/data/856/822/07/85682207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.495271,
-    "geom:area_square_m":15399102020.364119,
+    "geom:area_square_m":15399102157.600121,
     "geom:bbox":"-71.714492,-34.290669,-69.770032,-32.922479",
     "geom:latitude":-33.604596,
     "geom:longitude":-70.626919,
@@ -368,14 +368,16 @@
         "gn:id":3873544,
         "gp:id":2345029,
         "hasc:id":"CL.RM",
+        "iso:code":"CL-RM",
         "iso:id":"CL-RM",
         "wd:id":"Q2131"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93f424b5a7b35ef9ce11d41e5a8a71e1",
+    "wof:geomhash":"2637b3db90558e065904c33d55e9e5ed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -390,7 +392,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866947,
+    "wof:lastmodified":1695884501,
     "wof:name":"Metropolitana",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/822/33/85682233.geojson
+++ b/data/856/822/33/85682233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.25731,
-    "geom:area_square_m":48271421127.113754,
+    "geom:area_square_m":48271421524.190582,
     "geom:bbox":"-74.84898,-44.067119,-71.582377,-40.236539",
     "geom:latitude":-42.041382,
     "geom:longitude":-72.895505,
@@ -298,15 +298,17 @@
     "wof:concordances":{
         "fips:code":"CI14",
         "hasc:id":"CL.LG",
+        "iso:code":"CL-LL",
         "iso:id":"CL-LL",
         "unlc:id":"CL-LL",
         "wd:id":"Q2178"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"11bc7caf0ed8ef8cbab11b1cca1ca06c",
+    "wof:geomhash":"aeef464f81b1884549637bd0c51752c1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866937,
+    "wof:lastmodified":1695884618,
     "wof:name":"De Los Lagos",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/856/822/45/85682245.geojson
+++ b/data/856/822/45/85682245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.678266,
-    "geom:area_square_m":42679469289.997765,
+    "geom:area_square_m":42679468500.365112,
     "geom:bbox":"-70.286603,-21.631476,-68.436807,-18.935848",
     "geom:latitude":-20.209074,
     "geom:longitude":-69.396548,
@@ -362,14 +362,16 @@
         "gn:id":3870116,
         "gp:id":2345030,
         "hasc:id":"CL.TP",
+        "iso:code":"CL-TA",
         "iso:id":"CL-TA",
         "wd:id":"Q2114"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd30ce1ebf317208cdc78ad490d255c9",
+    "wof:geomhash":"7fc21de2a8ad6f7d7d762ca1e71ee350",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690866946,
+    "wof:lastmodified":1695884645,
     "wof:name":"De Tarapaca",
     "wof:parent_id":85633057,
     "wof:placetype":"region",

--- a/data/890/517/491/890517491.geojson
+++ b/data/890/517/491/890517491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.418918,
-    "geom:area_square_m":39681549211.442169,
+    "geom:area_square_m":39681548156.774719,
     "geom:bbox":"-70.286603,-21.631476,-68.436807,-18.935848",
     "geom:latitude":-20.164614,
     "geom:longitude":-69.3481,
@@ -85,12 +85,13 @@
         "hasc:id":"CL.TP.TM",
         "qs_pg:id":1308414
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CL",
     "wof:created":1469056011,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b07b372418f01e07b80672c53456c1c",
+    "wof:geomhash":"b406fac82a144406b78981c3700e2b1b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":890517491,
-    "wof:lastmodified":1627522004,
+    "wof:lastmodified":1695886489,
     "wof:name":"Tamarugal",
     "wof:parent_id":85682245,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.